### PR TITLE
Response cache

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -20,7 +20,8 @@
 	// Add the IDs of extensions you want installed when the container is created.
 	"extensions": [
 		"ms-dotnettools.csharp",
-		"editorconfig.editorconfig"
+        "editorconfig.editorconfig",
+        "eamodio.gitlens"
 	],
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -19,7 +19,8 @@
 
 	// Add the IDs of extensions you want installed when the container is created.
 	"extensions": [
-		"ms-dotnettools.csharp"
+		"ms-dotnettools.csharp",
+		"editorconfig.editorconfig"
 	],
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+# Remove the line below if you want to inherit .editorconfig settings from higher directories
+root = true
+
+# C# files
+[*.cs]
+
+# Indentation and spacing
+indent_size = 4
+indent_style = space
+tab_width = 4
+
+# New line preferences
+end_of_line = crlf
+insert_final_newline = false

--- a/benchmark.js
+++ b/benchmark.js
@@ -1,0 +1,11 @@
+import http from 'k6/http';
+import { check } from 'k6';
+
+const HOST = __ENV.BENCH_HOST
+
+export default function () {
+    let r = http.get(`${HOST}/api/stats`);
+    check(r, {
+        'status is 200': (r) => r.status === 200,
+    });
+}

--- a/sources/SloCovidServer/SloCovidServer/Controllers/DeceasedPerRegionsController.cs
+++ b/sources/SloCovidServer/SloCovidServer/Controllers/DeceasedPerRegionsController.cs
@@ -16,9 +16,10 @@ namespace SloCovidServer.Controllers
         {
         }
         [HttpGet]
-        public async Task<ActionResult<ImmutableArray<DeceasedPerRegionsDay>?>> Get(DateTime? from, DateTime? to)
+        [ResponseCache(VaryByQueryKeys = new[] {"*"}, Duration = 60)]
+        public Task<ActionResult<ImmutableArray<DeceasedPerRegionsDay>?>> Get(DateTime? from, DateTime? to)
         {
-            return await ProcessRequestAsync(communicator.GetDeceasedPerRegionsAsync, new DataFilter(from, to));
+            return ProcessRequestAsync(communicator.GetDeceasedPerRegionsAsync, new DataFilter(from, to));
         }
     }
 }

--- a/sources/SloCovidServer/SloCovidServer/Controllers/HealthCentersController.cs
+++ b/sources/SloCovidServer/SloCovidServer/Controllers/HealthCentersController.cs
@@ -16,9 +16,10 @@ namespace SloCovidServer.Controllers
         {
         }
         [HttpGet]
-        public async Task<ActionResult<ImmutableArray<HealthCentersDay>?>> Get(DateTime? from, DateTime? to)
+        [ResponseCache(VaryByQueryKeys = new[] {"*"}, Duration = 60)]
+        public Task<ActionResult<ImmutableArray<HealthCentersDay>?>> Get(DateTime? from, DateTime? to)
         {
-            return await ProcessRequestAsync(communicator.GetHealthCentersAsync, new DataFilter(from, to));
+            return ProcessRequestAsync(communicator.GetHealthCentersAsync, new DataFilter(from, to));
         }
     }
 }

--- a/sources/SloCovidServer/SloCovidServer/Controllers/HospitalsController.cs
+++ b/sources/SloCovidServer/SloCovidServer/Controllers/HospitalsController.cs
@@ -17,9 +17,10 @@ namespace SloCovidServer.Controllers
         }
 
         [HttpGet]
-        public async Task<ActionResult<ImmutableArray<HospitalsDay>?>> Get(DateTime? from, DateTime? to)
+        [ResponseCache(VaryByQueryKeys = new[] {"*"}, Duration = 60)]
+        public Task<ActionResult<ImmutableArray<HospitalsDay>?>> Get(DateTime? from, DateTime? to)
         {
-            return await ProcessRequestAsync(communicator.GetHospitalsAsync, new DataFilter(from, to));
+            return ProcessRequestAsync(communicator.GetHospitalsAsync, new DataFilter(from, to));
         }
     }
 }

--- a/sources/SloCovidServer/SloCovidServer/Controllers/HospitalsListController.cs
+++ b/sources/SloCovidServer/SloCovidServer/Controllers/HospitalsListController.cs
@@ -17,9 +17,10 @@ namespace SloCovidServer.Controllers
         }
 
         [HttpGet]
-        public async Task<ActionResult<ImmutableArray<Hospital>?>> Get()
+        [ResponseCache(VaryByQueryKeys = new[] {"*"}, Duration = 60)]
+        public Task<ActionResult<ImmutableArray<Hospital>?>> Get()
         {
-            return await ProcessRequestAsync(communicator.GetHospitalsListAsync, DataFilter.Empty);
+            return ProcessRequestAsync(communicator.GetHospitalsListAsync, DataFilter.Empty);
         }
     }
 }

--- a/sources/SloCovidServer/SloCovidServer/Controllers/MunicipalitiesController.cs
+++ b/sources/SloCovidServer/SloCovidServer/Controllers/MunicipalitiesController.cs
@@ -16,9 +16,10 @@ namespace SloCovidServer.Controllers
         {
         }
         [HttpGet]
-        public async Task<ActionResult<ImmutableArray<MunicipalityDay>?>> Get(DateTime? from, DateTime? to)
+        [ResponseCache(VaryByQueryKeys = new[] {"*"}, Duration = 60)]
+        public Task<ActionResult<ImmutableArray<MunicipalityDay>?>> Get(DateTime? from, DateTime? to)
         {
-            return await ProcessRequestAsync(communicator.GetMunicipalitiesAsync, new DataFilter(from, to));
+            return ProcessRequestAsync(communicator.GetMunicipalitiesAsync, new DataFilter(from, to));
         }
     }
 }

--- a/sources/SloCovidServer/SloCovidServer/Controllers/MunicipalityListController.cs
+++ b/sources/SloCovidServer/SloCovidServer/Controllers/MunicipalityListController.cs
@@ -17,9 +17,10 @@ namespace SloCovidServer.Controllers
         }
 
         [HttpGet]
-        public async Task<ActionResult<ImmutableArray<Municipality>?>> Get()
+        [ResponseCache(VaryByQueryKeys = new[] {"*"}, Duration = 60)]
+        public Task<ActionResult<ImmutableArray<Municipality>?>> Get()
         {
-            return await ProcessRequestAsync(communicator.GetMunicipalitiesListAsync, DataFilter.Empty);
+            return ProcessRequestAsync(communicator.GetMunicipalitiesListAsync, DataFilter.Empty);
         }
     }
 }

--- a/sources/SloCovidServer/SloCovidServer/Controllers/PatientsController.cs
+++ b/sources/SloCovidServer/SloCovidServer/Controllers/PatientsController.cs
@@ -17,9 +17,10 @@ namespace SloCovidServer.Controllers
         }
 
         [HttpGet]
-        public async Task<ActionResult<ImmutableArray<PatientsDay>?>> Get(DateTime? from, DateTime? to)
+        [ResponseCache(VaryByQueryKeys = new[] {"*"}, Duration = 60)]
+        public Task<ActionResult<ImmutableArray<PatientsDay>?>> Get(DateTime? from, DateTime? to)
         {
-            return await ProcessRequestAsync(communicator.GetPatientsAsync, new DataFilter(from, to));
+            return ProcessRequestAsync(communicator.GetPatientsAsync, new DataFilter(from, to));
         }
     }
 }

--- a/sources/SloCovidServer/SloCovidServer/Controllers/RegionsController.cs
+++ b/sources/SloCovidServer/SloCovidServer/Controllers/RegionsController.cs
@@ -18,9 +18,10 @@ namespace SloCovidServer.Controllers
 
         [HttpGet]
         [Route("regions")]
-        public async Task<ActionResult<ImmutableArray<RegionsDay>?>> Get(DateTime? from, DateTime? to)
+        [ResponseCache(VaryByQueryKeys = new[] {"*"}, Duration = 60)]
+        public Task<ActionResult<ImmutableArray<RegionsDay>?>> Get(DateTime? from, DateTime? to)
         {
-            return await ProcessRequestAsync(communicator.GetRegionsAsync, new DataFilter(from, to));
+            return ProcessRequestAsync(communicator.GetRegionsAsync, new DataFilter(from, to));
         }
     }
 }

--- a/sources/SloCovidServer/SloCovidServer/Controllers/RetirementHomesController.cs
+++ b/sources/SloCovidServer/SloCovidServer/Controllers/RetirementHomesController.cs
@@ -16,9 +16,10 @@ namespace SloCovidServer.Controllers
         {
         }
         [HttpGet]
-        public async Task<ActionResult<ImmutableArray<RetirementHomesDay>?>> Get(DateTime? from, DateTime? to)
+        [ResponseCache(VaryByQueryKeys = new[] {"*"}, Duration = 60)]
+        public Task<ActionResult<ImmutableArray<RetirementHomesDay>?>> Get(DateTime? from, DateTime? to)
         {
-            return await ProcessRequestAsync(communicator.GetRetirementHomesAsync, new DataFilter(from, to));
+            return ProcessRequestAsync(communicator.GetRetirementHomesAsync, new DataFilter(from, to));
         }
     }
 }

--- a/sources/SloCovidServer/SloCovidServer/Controllers/RetirementHomesListController.cs
+++ b/sources/SloCovidServer/SloCovidServer/Controllers/RetirementHomesListController.cs
@@ -10,15 +10,16 @@ namespace SloCovidServer.Controllers
 {
     [ApiController]
     [Route("api/retirement-homes-list")]
-    public class RetirementHomesListController: MetricsController<RetirementHomesListController>
+    public class RetirementHomesListController : MetricsController<RetirementHomesListController>
     {
         public RetirementHomesListController(ILogger<RetirementHomesListController> logger, ICommunicator communicator) : base(logger, communicator)
         {
         }
         [HttpGet]
-        public async Task<ActionResult<ImmutableArray<RetirementHome>?>> Get()
+        [ResponseCache(VaryByQueryKeys = new[] {"*"}, Duration = 60)]
+        public Task<ActionResult<ImmutableArray<RetirementHome>?>> Get()
         {
-            return await ProcessRequestAsync(communicator.GetRetirementHomesListAsync, DataFilter.Empty);
+            return ProcessRequestAsync(communicator.GetRetirementHomesListAsync, DataFilter.Empty);
         }
     }
 }

--- a/sources/SloCovidServer/SloCovidServer/Controllers/StatsController.cs
+++ b/sources/SloCovidServer/SloCovidServer/Controllers/StatsController.cs
@@ -17,9 +17,10 @@ namespace SloCovidServer.Controllers
         {} 
 
         [HttpGet]
-        public async Task<ActionResult<ImmutableArray<StatsDaily>?>> Get(DateTime? from, DateTime? to)
+        [ResponseCache(VaryByQueryKeys = new[] {"*"}, Duration = 60)]
+        public Task<ActionResult<ImmutableArray<StatsDaily>?>> Get(DateTime? from, DateTime? to)
         {
-            return await ProcessRequestAsync(communicator.GetStatsAsync, new DataFilter(from, to));
+            return ProcessRequestAsync(communicator.GetStatsAsync, new DataFilter(from, to));
         }
     }
 }

--- a/sources/SloCovidServer/SloCovidServer/Controllers/StatsWeeklyController.cs
+++ b/sources/SloCovidServer/SloCovidServer/Controllers/StatsWeeklyController.cs
@@ -17,9 +17,10 @@ namespace SloCovidServer.Controllers
 
         }
         [HttpGet]
-        public async Task<ActionResult<ImmutableArray<StatsWeeklyDay>?>> Get(DateTime? from, DateTime? to)
+        [ResponseCache(VaryByQueryKeys = new[] {"*"}, Duration = 60)]
+        public Task<ActionResult<ImmutableArray<StatsWeeklyDay>?>> Get(DateTime? from, DateTime? to)
         {
-            return await ProcessRequestAsync(communicator.GetStatsWeeklyAsync, new DataFilter(from, to));
+            return ProcessRequestAsync(communicator.GetStatsWeeklyAsync, new DataFilter(from, to));
         }
     }
 }

--- a/sources/SloCovidServer/SloCovidServer/EndpointCache`1.cs
+++ b/sources/SloCovidServer/SloCovidServer/EndpointCache`1.cs
@@ -52,7 +52,6 @@ namespace SloCovidServer.Services.Implemented
         {
             get
             {
-                sync.EnterReadLock();
                 if (!this.initialized)
                 {
                     // wait for promise resolution on first request
@@ -61,7 +60,7 @@ namespace SloCovidServer.Services.Implemented
                         throw new System.Exception("Timeout waiting cache");
                     }
                 }
-
+                sync.EnterReadLock();
                 try
                 {
                     return cache;

--- a/sources/SloCovidServer/SloCovidServer/EndpointCache`1.cs
+++ b/sources/SloCovidServer/SloCovidServer/EndpointCache`1.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Immutable;
 using System.Threading;
+using System.Threading.Tasks;
 
 namespace SloCovidServer.Services.Implemented
 {
@@ -10,7 +11,10 @@ namespace SloCovidServer.Services.Implemented
     public class EndpointCache<T>
     {
         readonly ReaderWriterLockSlim sync = new ReaderWriterLockSlim();
+        private TaskCompletionSource<bool> initPromise = new TaskCompletionSource<bool>();
+        private bool initialized = false;
         ETagCacheItem<T> cache;
+
         public ETagCacheItem<T> Cache
         {
             get
@@ -30,11 +34,41 @@ namespace SloCovidServer.Services.Implemented
                 sync.EnterWriteLock();
                 try
                 {
+                    if (!this.initialized)
+                    {
+                        // resolve promise on first instance
+                        this.initialized = true;
+                        this.initPromise.SetResult(true);
+                    }
                     cache = value;
                 }
                 finally
                 {
                     sync.ExitWriteLock();
+                }
+            }
+        }
+        public ETagCacheItem<T> CacheBlocking
+        {
+            get
+            {
+                sync.EnterReadLock();
+                if (!this.initialized)
+                {
+                    // wait for promise resolution on first request
+                    if (!this.initPromise.Task.Wait(5000))
+                    {
+                        throw new System.Exception("Timeout waiting cache");
+                    }
+                }
+
+                try
+                {
+                    return cache;
+                }
+                finally
+                {
+                    sync.ExitReadLock();
                 }
             }
         }

--- a/sources/SloCovidServer/SloCovidServer/Services/Implemented/Communicator.cs
+++ b/sources/SloCovidServer/SloCovidServer/Services/Implemented/Communicator.cs
@@ -24,35 +24,35 @@ namespace SloCovidServer.Services.Implemented
         readonly Mapper mapper;
         readonly ISlackService slackService;
         protected static readonly Histogram RequestDuration = Metrics.CreateHistogram("source_request_duration_milliseconds",
-            "Request duration to CSV sources in milliseconds",
-            new HistogramConfiguration
-            {
-                Buckets = Histogram.ExponentialBuckets(start: 20, factor: 2, count: 10),
-                LabelNames = new[] { "endpoint", "is_exception" }
-            });
+                "Request duration to CSV sources in milliseconds",
+                new HistogramConfiguration
+                {
+                    Buckets = Histogram.ExponentialBuckets(start: 20, factor: 2, count: 10),
+                    LabelNames = new[] { "endpoint", "is_exception" }
+                });
         protected static readonly Counter RequestCount = Metrics.CreateCounter("source_request_total", "Total number of requests to source",
-            new CounterConfiguration
-            {
-                LabelNames = new[] { "endpoint" }
-            });
-        protected static readonly Counter RequestMissedCache = Metrics.CreateCounter("source_request_missed_cache_total", 
-            "Total number of missed cache when fetching from source",
-            new CounterConfiguration
-            {
-                LabelNames = new[] { "endpoint" }
-            });
-        protected static readonly Counter RequestExceptions = Metrics.CreateCounter("source_request_exceptions_total", 
-            "Total number of exceptions when fetching data from source",
-            new CounterConfiguration
-            {
-                LabelNames = new[] { "endpoint" }
-            });
+                new CounterConfiguration
+                {
+                    LabelNames = new[] { "endpoint" }
+                });
+        protected static readonly Counter RequestMissedCache = Metrics.CreateCounter("source_request_missed_cache_total",
+                "Total number of missed cache when fetching from source",
+                new CounterConfiguration
+                {
+                    LabelNames = new[] { "endpoint" }
+                });
+        protected static readonly Counter RequestExceptions = Metrics.CreateCounter("source_request_exceptions_total",
+                "Total number of exceptions when fetching data from source",
+                new CounterConfiguration
+                {
+                    LabelNames = new[] { "endpoint" }
+                });
         protected static readonly Gauge EndpointDown = Metrics.CreateGauge("endpoint_down",
-           "When above 0 means that given endpoint is unreachable",
-           new GaugeConfiguration
-           {
-               LabelNames = new[] { "endpoint" }
-           });
+       "When above 0 means that given endpoint is unreachable",
+       new GaugeConfiguration
+       {
+         LabelNames = new[] { "endpoint" }
+       });
         readonly ArrayEndpointCache<StatsDaily> statsCache;
         readonly ArrayEndpointCache<RegionsDay> regionCache;
         readonly ArrayEndpointCache<PatientsDay> patientsCache;
@@ -90,91 +90,79 @@ namespace SloCovidServer.Services.Implemented
             errors = new ConcurrentDictionary<string, object>();
         }
 
-        public async Task<(ImmutableArray<StatsDaily>? Data, string ETag, long? Timestamp)> GetStatsAsync(string callerEtag, DataFilter filter, CancellationToken ct)
+        public Task<(ImmutableArray<StatsDaily>? Data, string ETag, long? Timestamp)> GetStatsAsync(string callerEtag, DataFilter filter, CancellationToken ct)
         {
-            var result = await GetAsync(callerEtag, $"{root}/stats.csv", statsCache, mapFromString: mapper.GetStatsFromRaw, filter, ct);
-            return result;
+            return GetAsync(callerEtag, $"{root}/stats.csv", statsCache, mapFromString: mapper.GetStatsFromRaw, filter, ct);
         }
 
-        public async Task<(ImmutableArray<RegionsDay>? Data, string ETag, long? Timestamp)> GetRegionsAsync(string callerEtag, DataFilter filter, CancellationToken ct)
+        public Task<(ImmutableArray<RegionsDay>? Data, string ETag, long? Timestamp)> GetRegionsAsync(string callerEtag, DataFilter filter, CancellationToken ct)
         {
-            var result = await GetAsync(callerEtag, $"{root}/regions.csv",regionCache, mapFromString: mapper.GetRegionsFromRaw, filter, ct);
-            return result;
+            return GetAsync(callerEtag, $"{root}/regions.csv", regionCache, mapFromString: mapper.GetRegionsFromRaw, filter, ct);
         }
 
-        public async Task<(ImmutableArray<PatientsDay>? Data, string ETag, long? Timestamp)> GetPatientsAsync(string callerEtag, DataFilter filter, CancellationToken ct)
+        public Task<(ImmutableArray<PatientsDay>? Data, string ETag, long? Timestamp)> GetPatientsAsync(string callerEtag, DataFilter filter, CancellationToken ct)
         {
-            var result = await GetAsync(callerEtag, $"{root}/patients.csv", patientsCache, mapFromString: mapper.GetPatientsFromRaw, filter, ct);
-            return result;
+            return GetAsync(callerEtag, $"{root}/patients.csv", patientsCache, mapFromString: mapper.GetPatientsFromRaw, filter, ct);
         }
 
-        public async Task<(ImmutableArray<HospitalsDay>? Data, string ETag, long? Timestamp)> GetHospitalsAsync(string callerEtag, DataFilter filter, CancellationToken ct)
+        public Task<(ImmutableArray<HospitalsDay>? Data, string ETag, long? Timestamp)> GetHospitalsAsync(string callerEtag, DataFilter filter, CancellationToken ct)
         {
-            var result = await GetAsync(callerEtag, $"{root}/hospitals.csv", hospitalsCache, mapFromString: mapper.GetHospitalsFromRaw, filter, ct);
-            return result;
+            return GetAsync(callerEtag, $"{root}/hospitals.csv", hospitalsCache, mapFromString: mapper.GetHospitalsFromRaw, filter, ct);
         }
 
-        public async Task<(ImmutableArray<Hospital>? Data, string ETag, long? Timestamp)> GetHospitalsListAsync(string callerEtag, DataFilter filter, CancellationToken ct)
+        public Task<(ImmutableArray<Hospital>? Data, string ETag, long? Timestamp)> GetHospitalsListAsync(string callerEtag, DataFilter filter, CancellationToken ct)
         {
-            var result = await GetAsync(callerEtag, $"{root}/dict-hospitals.csv",hospitalsListCache, mapFromString: mapper.GetHospitalsListFromRaw, filter, ct);
-            return result;
+            return GetAsync(callerEtag, $"{root}/dict-hospitals.csv", hospitalsListCache, mapFromString: mapper.GetHospitalsListFromRaw, filter, ct);
         }
 
-        public async Task<(ImmutableArray<Municipality>? Data, string ETag, long? Timestamp)> GetMunicipalitiesListAsync(string callerEtag, DataFilter filter, CancellationToken ct)
+        public Task<(ImmutableArray<Municipality>? Data, string ETag, long? Timestamp)> GetMunicipalitiesListAsync(string callerEtag, DataFilter filter, CancellationToken ct)
         {
-            var result = await GetAsync(callerEtag, $"{root}/dict-municipality.csv",municipalitiesListCache, mapFromString: mapper.GetMunicipalitiesListFromRaw, filter, ct);
-            return result;
+            return GetAsync(callerEtag, $"{root}/dict-municipality.csv", municipalitiesListCache, mapFromString: mapper.GetMunicipalitiesListFromRaw, filter, ct);
         }
 
-        public async Task<(ImmutableArray<RetirementHome>? Data, string ETag, long? Timestamp)> GetRetirementHomesListAsync(string callerEtag, DataFilter filter, CancellationToken ct)
+        public Task<(ImmutableArray<RetirementHome>? Data, string ETag, long? Timestamp)> GetRetirementHomesListAsync(string callerEtag, DataFilter filter, CancellationToken ct)
         {
-            var result = await GetAsync(callerEtag, $"{root}/dict-retirement_homes.csv", retirementHomesListCache, 
-                mapFromString: mapper.GetRetirementHomesListFromRaw, filter, ct);
-            return result;
+            return GetAsync(callerEtag, $"{root}/dict-retirement_homes.csv", retirementHomesListCache,
+                    mapFromString: mapper.GetRetirementHomesListFromRaw, filter, ct);
         }
 
-        public async Task<(ImmutableArray<RetirementHomesDay>? Data, string ETag, long? Timestamp)> GetRetirementHomesAsync(string callerEtag, DataFilter filter, CancellationToken ct)
+        public Task<(ImmutableArray<RetirementHomesDay>? Data, string ETag, long? Timestamp)> GetRetirementHomesAsync(string callerEtag, DataFilter filter, CancellationToken ct)
         {
-            var result = await GetAsync(callerEtag, $"{root}/retirement_homes.csv", retirementHomesCache,
-                mapFromString: mapper.GetRetirementHomesFromRaw, filter, ct);
-            return result;
+            return GetAsync(callerEtag, $"{root}/retirement_homes.csv", retirementHomesCache,
+                    mapFromString: mapper.GetRetirementHomesFromRaw, filter, ct);
         }
 
-        public async Task<(ImmutableArray<DeceasedPerRegionsDay>? Data, string ETag, long? Timestamp)> GetDeceasedPerRegionsAsync(string callerEtag, DataFilter filter, CancellationToken ct)
+        public Task<(ImmutableArray<DeceasedPerRegionsDay>? Data, string ETag, long? Timestamp)> GetDeceasedPerRegionsAsync(string callerEtag, DataFilter filter, CancellationToken ct)
         {
-            var result = await GetAsync(callerEtag, $"{root}/deceased-regions.csv", deceasedPerRegionsDayCache,
-                mapFromString: new DeceasedPerRegionsMapper().GetDeceasedPerRegionsDayFromRaw, filter, ct);
-            return result;
+            return GetAsync(callerEtag, $"{root}/deceased-regions.csv", deceasedPerRegionsDayCache,
+                    mapFromString: new DeceasedPerRegionsMapper().GetDeceasedPerRegionsDayFromRaw, filter, ct);
         }
 
-        public async Task<(ImmutableArray<MunicipalityDay>? Data, string ETag, long? Timestamp)> GetMunicipalitiesAsync(string callerEtag, DataFilter filter, CancellationToken ct)
+        public Task<(ImmutableArray<MunicipalityDay>? Data, string ETag, long? Timestamp)> GetMunicipalitiesAsync(string callerEtag, DataFilter filter, CancellationToken ct)
         {
-            var result = await GetAsync(callerEtag, $"{root}/municipality.csv", municipalityDayCache,
-                mapFromString: new MunicipalitiesMapper().GetMunicipalityDayFromRaw, filter, ct);
-            return result;
+            return GetAsync(callerEtag, $"{root}/municipality.csv", municipalityDayCache,
+                    mapFromString: new MunicipalitiesMapper().GetMunicipalityDayFromRaw, filter, ct);
         }
 
-        public async Task<(ImmutableArray<HealthCentersDay>? Data, string ETag, long? Timestamp)> GetHealthCentersAsync(string callerEtag, DataFilter filter, CancellationToken ct)
+        public Task<(ImmutableArray<HealthCentersDay>? Data, string ETag, long? Timestamp)> GetHealthCentersAsync(string callerEtag, DataFilter filter, CancellationToken ct)
         {
-            var result = await GetAsync(callerEtag, $"{root}/health_centers.csv", healthCentersDayCache,
-                mapFromString: new HealthCentersMapper().GetHealthCentersDayFromRaw, filter, ct);
-            return result;
+            return GetAsync(callerEtag, $"{root}/health_centers.csv", healthCentersDayCache,
+                    mapFromString: new HealthCentersMapper().GetHealthCentersDayFromRaw, filter, ct);
         }
 
-        public async Task<(ImmutableArray<StatsWeeklyDay>? Data, string ETag, long? Timestamp)> GetStatsWeeklyAsync(string callerEtag, DataFilter filter, CancellationToken ct)
+        public Task<(ImmutableArray<StatsWeeklyDay>? Data, string ETag, long? Timestamp)> GetStatsWeeklyAsync(string callerEtag, DataFilter filter, CancellationToken ct)
         {
-            var result = await GetAsync(callerEtag, $"{root}/stats-weekly.csv", statsWeeklyDayCache,
-                mapFromString: new StatsWeeklyMapper().GetStatsWeeklyDayFromRaw, filter, ct);
-            return result;
+            return GetAsync(callerEtag, $"{root}/stats-weekly.csv", statsWeeklyDayCache,
+                    mapFromString: new StatsWeeklyMapper().GetStatsWeeklyDayFromRaw, filter, ct);
         }
 
         public class RegionsPivotCacheData
         {
             public ETagCacheItem<ImmutableArray<Municipality>> Municipalities { get; }
             public ETagCacheItem<ImmutableArray<RegionsDay>> Regions { get; }
-            public ImmutableArray<ImmutableArray<object>> Data { get;}
+            public ImmutableArray<ImmutableArray<object>> Data { get; }
             public RegionsPivotCacheData(ETagCacheItem<ImmutableArray<Municipality>> municipalities, ETagCacheItem<ImmutableArray<RegionsDay>> regions,
-                ImmutableArray<ImmutableArray<object>> data)
+                    ImmutableArray<ImmutableArray<object>> data)
             {
                 Municipalities = municipalities;
                 Regions = regions;
@@ -182,9 +170,9 @@ namespace SloCovidServer.Services.Implemented
             }
         }
         RegionsPivotCacheData regionsPivotCacheData = new RegionsPivotCacheData(
-            new ETagCacheItem<ImmutableArray<Municipality>>(null, ImmutableArray<Municipality>.Empty, timestamp: null),
-            new ETagCacheItem<ImmutableArray<RegionsDay>>(null, ImmutableArray<RegionsDay>.Empty, timestamp: null),
-            data: ImmutableArray<ImmutableArray<object>>.Empty
+                new ETagCacheItem<ImmutableArray<Municipality>>(null, ImmutableArray<Municipality>.Empty, timestamp: null),
+                new ETagCacheItem<ImmutableArray<RegionsDay>>(null, ImmutableArray<RegionsDay>.Empty, timestamp: null),
+                data: ImmutableArray<ImmutableArray<object>>.Empty
         );
         readonly object syncRegionsPivot = new object();
         //public async Task<(ImmutableArray<ImmutableArray<object>>? Data, string ETag)>  GetRegionsPivotAsync(string callerEtag, CancellationToken ct)
@@ -288,36 +276,38 @@ namespace SloCovidServer.Services.Implemented
         /// <returns></returns>
         /// <remarks>This method might update sync.Cache but only to refresh its Created property.</remarks>
         async Task<(HttpResponseMessage Response, ETagCacheItem<TData> Current, string Timestamp)> FetchDataAsync<TData>(
-            string url, EndpointCache<TData> sync, ETagCacheItem<TData> current, CancellationToken ct)
-            where TData : struct
+                string url, EndpointCache<TData> sync, ETagCacheItem<TData> current, CancellationToken ct)
+                where TData : struct
         {
-            async Task ProcessErrorAsync(string message)
+            Task ProcessErrorAsync(string message)
             {
                 if (errors.TryAdd(url, null))
                 {
                     EndpointDown.WithLabels(url).Inc();
-                    await slackService.SendNotificationAsync($"DATA API REST service started failing to retrieve data from {url} because {message}",
-                        CancellationToken.None);
+                    slackService.SendNotificationAsync($"DATA API REST service started failing to retrieve data from {url} because {message}",
+                            CancellationToken.None);
                 }
                 else
                 {
-                    await slackService.SendNotificationAsync($"DATA API REST service failed retrieving data from {url} because {message}",
-                        CancellationToken.None);
+                    slackService.SendNotificationAsync($"DATA API REST service failed retrieving data from {url} because {message}",
+                            CancellationToken.None);
                 }
+                return null;
             }
-            async Task ProcessErrorRemovalAsync()
+            Task ProcessErrorRemovalAsync()
             {
                 // remove error flag
                 if (errors.TryRemove(url, out _))
                 {
                     EndpointDown.WithLabels(url).Dec();
-                    await slackService.SendNotificationAsync($"DATA API REST service started retrieving data from {url}", CancellationToken.None);
+                    slackService.SendNotificationAsync($"DATA API REST service started retrieving data from {url}", CancellationToken.None);
                 }
+                return null;
             }
 
             var policy = HttpPolicyExtensions
-              .HandleTransientHttpError()
-              .RetryAsync(1);
+                .HandleTransientHttpError()
+                .RetryAsync(1);
 
             HttpResponseMessage response;
             // cache responses for a minute
@@ -427,21 +417,28 @@ namespace SloCovidServer.Services.Implemented
         /// <remarks>
         /// In cache is always all data though filtered is returned.
         /// </remarks>
-        async Task<(ImmutableArray<TData>? Data, string ETag, long? Timestamp)> GetAsync<TData>(string callerEtag, string url, 
-            EndpointCache<ImmutableArray<TData>> sync, Func<string, ImmutableArray<TData>> mapFromString, DataFilter filter, CancellationToken ct)
-            where TData: class
+        async Task<(ImmutableArray<TData>? Data, string ETag, long? Timestamp)> GetAsync<TData>(string callerEtag, string url,
+                EndpointCache<ImmutableArray<TData>> sync, Func<string, ImmutableArray<TData>> mapFromString, DataFilter filter, CancellationToken ct)
+                where TData : class
         {
             var stopwatch = Stopwatch.StartNew();
 
-            ETagCacheItem<ImmutableArray<TData>> current = sync.Cache;
+
 
             bool isException = false;
-            try
+
+            string timestampText;
+            string etagInfo = $"ETag {(string.IsNullOrEmpty(callerEtag) ? "none" : "present")}";
+
+            // current might have been updated with new Created date
+            FetchDataAsync(url, sync, sync.Cache, ct).ContinueWith((task) =>
             {
+                // this task will refresh EndpointCache in background, without blocking request
+                // so client might not get latest data immediately, but he will eventually
                 HttpResponseMessage response;
-                string timestampText;
-                // current might have been updated with new Created date
-                (response, current, timestampText) = await FetchDataAsync(url, sync, current, ct);
+                ETagCacheItem<ImmutableArray<TData>> current;
+                (response, current, timestampText) = task.Result;
+
                 long? timestamp;
                 if (long.TryParse(timestampText, out long ts))
                 {
@@ -452,23 +449,14 @@ namespace SloCovidServer.Services.Implemented
                     timestamp = null;
                 }
 
-                string etagInfo = $"ETag {(string.IsNullOrEmpty(callerEtag) ? "none" : "present")}";
                 if (response?.IsSuccessStatusCode ?? false)
                 {
                     RequestMissedCache.WithLabels(url).Inc();
                     string newETag = response.Headers.GetValues("ETag").SingleOrDefault();
-                    string content = await response.Content.ReadAsStringAsync();
-                    var newData = mapFromString(content);
-                    current = new ETagCacheItem<ImmutableArray<TData>>(newETag, newData, timestamp);
-                    sync.Cache = current;
-                    if (string.Equals(current.ETag, callerEtag, StringComparison.Ordinal))
-                    {
-                        logger.LogInformation($"Cache refreshed, client cache hit, {etagInfo}");
-                        return (null, current.ETag, current.Timestamp);
-                    }
-                    logger.LogInformation($"Cache refreshed, client refreshed, {etagInfo}");
-                    var filteredData = FilterData(current.Data, filter);
-                    return (filteredData, current.ETag, current.Timestamp);
+                    response.Content.ReadAsStringAsync().ContinueWith((task) =>
+                                        {
+                                            sync.Cache = new ETagCacheItem<ImmutableArray<TData>>(newETag, mapFromString(task.Result), timestamp);
+                                        });
                 }
                 else if (response == null || response.StatusCode == System.Net.HttpStatusCode.NotModified)
                 {
@@ -477,19 +465,27 @@ namespace SloCovidServer.Services.Implemented
                     {
                         sync.Cache = new ETagCacheItem<ImmutableArray<TData>>(current.ETag, current.Data, current.Timestamp);
                     }
-                    if (string.Equals(current.ETag, callerEtag, StringComparison.Ordinal))
-                    {
-                        logger.LogInformation($"Cache hit, client cache hit, {etagInfo}");
-                        return (null, current.ETag, current.Timestamp);
-                    }
-                    else
-                    {
-                        logger.LogInformation($"Cache hit, client cache refreshed, {etagInfo}");
-                        var filteredData = FilterData(current.Data, filter);
-                        return (filteredData, current.ETag, current.Timestamp);
-                    }
                 }
-                throw new Exception($"Failed fetching data: {response.ReasonPhrase}");
+            });
+
+            try
+            {
+
+                ETagCacheItem<ImmutableArray<TData>> current = sync.CacheBlocking;
+
+                if (string.Equals(current.ETag, callerEtag, StringComparison.Ordinal))
+                {
+                    logger.LogInformation($"Cache hit, client cache hit, {etagInfo}");
+                    return (null, current.ETag, current.Timestamp);
+                }
+                else
+                {
+                    logger.LogInformation($"Cache hit, client cache refreshed, {etagInfo}");
+                    var filteredData = FilterData(current.Data, filter);
+                    return (filteredData, current.ETag, current.Timestamp);
+                }
+
+                // throw new Exception($"Failed fetching data: {response.ReasonPhrase}");
             }
             catch
             {


### PR DESCRIPTION
Implementation of response caching

Current master does not actually cache reponse, just data that is used to generate.

Before merge, it needs test of all endpoints (or deploy it during night and test on production :p). Integrated tests are still passing :)

# benchmarks

Using https://k6.io/

`k6 run -e BENCH_HOST=http://127.0.0.1:5555 --vus 10 --duration 1m ../data-api/benchmark.js`

## master benchmarks
```
    checks.....................: 100.00% ✓ 48658 ✗ 0   
    data_received..............: 30 GB   506 MB/s
    data_sent..................: 4.3 MB  72 kB/s
    http_req_blocked...........: avg=5.24µs  min=891ns    med=3.31µs   max=11.61ms p(90)=5.55µs  p(95)=6.62µs 
    http_req_connecting........: avg=35ns    min=0s       med=0s       max=223.9µs p(90)=0s      p(95)=0s     
    http_req_duration..........: avg=12.13ms min=6.03ms   med=10.21ms  max=1.06s   p(90)=18.13ms p(95)=21.15ms
    http_req_receiving.........: avg=9.74ms  min=338.57µs med=8.43ms   max=74.96ms p(90)=15.41ms p(95)=18.11ms
    http_req_sending...........: avg=43.1µs  min=6.78µs   med=17.88µs  max=18.75ms p(90)=29.31µs p(95)=35.62µs
    http_req_tls_handshaking...: avg=0s      min=0s       med=0s       max=0s      p(90)=0s      p(95)=0s     
    http_req_waiting...........: avg=2.35ms  min=319.93µs med=958.99µs max=1.04s   p(90)=5.49ms  p(95)=7.51ms 
    http_reqs..................: 48658   810.564484/s
    iteration_duration.........: avg=12.31ms min=6.12ms   med=10.39ms  max=1.06s   p(90)=18.37ms p(95)=21.41ms
    iterations.................: 48658   810.564484/s
    vus........................: 10      min=10  max=10
    vus_max....................: 10      min=10  max=10
```
## response-cache benchmarks

```
    checks.....................: 100.00% ✓ 161507 ✗ 0   
    data_received..............: 101 GB  1.7 GB/s
    data_sent..................: 14 MB   240 kB/s
    http_req_blocked...........: avg=7.05µs  min=872ns    med=4.42µs  max=13.31ms  p(90)=9.05µs  p(95)=11.77µs
    http_req_connecting........: avg=9ns     min=0s       med=0s      max=231.82µs p(90)=0s      p(95)=0s     
    http_req_duration..........: avg=3.45ms  min=752.6µs  med=2.76ms  max=700.86ms p(90)=5.81ms  p(95)=7.38ms 
    http_req_receiving.........: avg=1.78ms  min=188.01µs med=1.43ms  max=98.47ms  p(90)=3.15ms  p(95)=4.45ms 
    http_req_sending...........: avg=37.28µs min=6µs      med=21.61µs max=31.89ms  p(90)=38.02µs p(95)=47.49µs
    http_req_tls_handshaking...: avg=0s      min=0s       med=0s      max=0s       p(90)=0s      p(95)=0s     
    http_req_waiting...........: avg=1.63ms  min=141.89µs med=1.08ms  max=659.91ms p(90)=3.26ms  p(95)=4.73ms 
    http_reqs..................: 161507  2690.644364/s
    iteration_duration.........: avg=3.69ms  min=814.49µs med=2.97ms  max=701.4ms  p(90)=6.15ms  p(95)=7.77ms 
    iterations.................: 161507  2690.644364/s
    vus........................: 10      min=10   max=10
    vus_max....................: 10      min=10   max=10
```
